### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Laptop, Chrome browser and a text editor. We recommend Sublime Text 3 for this c
 
 
 
-##Resources
+## Resources
 
 **Scope and Closure:** http://speakingjs.com/es5/ch16.html

--- a/callbacks/callbackExercises.md
+++ b/callbacks/callbackExercises.md
@@ -1,4 +1,4 @@
-#Callback Exercises
+# Callback Exercises
 
 1. Write a function, `funcCaller`, that takes a `func` (a function) and an `arg` (any data type). The function returns the `func` called with `arg`(as an argument).
 

--- a/closures/closureExercises.md
+++ b/closures/closureExercises.md
@@ -1,4 +1,4 @@
-##Closure exercises
+## Closure exercises
 
 1. Write a function, `nonsense` that takes an input `string`. This function contains another function, `blab` which alerts `string` and is immediately called inside the function `nonsense`. `blab` should look like this inside of the `nonsense` function:
 

--- a/scope/scopeExercises.md
+++ b/scope/scopeExercises.md
@@ -1,9 +1,9 @@
-#[Function Scope Exercises](id:xcredit)
+# [Function Scope Exercises](id:xcredit)
 
 
-#####It is your mission to go through the function.js file and change all the `'???'` in such a way that all the tests pass true. 
+##### It is your mission to go through the function.js file and change all the `'???'` in such a way that all the tests pass true. 
 
-###Let's get started...
+### Let's get started...
 
  
 Run the  file in a browser. This document shows one passed test and a series of failing tests.
@@ -12,7 +12,7 @@ The **functions.js** folder holds all the failing tests that are being displayed
 
 A test block starts with an `it` function. The `it` function takes two arguments. The first one is a statement describing the rule addressed by the test. The second is a function that will either evaluate to true or false using the `expect` function. The expect statement (`expect(ACTUAL === 'inner').to.be.true;`) will evaluate if the statement between the parens `ACTUAL === 'inner'` is true. You can almost read it like plain English. The expect statement below "expects that the variable ACTUAL equals the value 'inner' to be true".
 
-####Failing Test Example
+#### Failing Test Example
 
       it('a function has access to its own local scope variables', 
      
@@ -26,7 +26,7 @@ A test block starts with an `it` function. The `it` function takes two arguments
         //change '???' to what ACTUAL evaluates to.
       });
       
-####Passing Test Example
+#### Passing Test Example
 
       it('a function has access to its own local scope variables', 
      

--- a/underscore-extra-credit/underscoreExercises.md
+++ b/underscore-extra-credit/underscoreExercises.md
@@ -1,4 +1,4 @@
-##Underscore exercises
+## Underscore exercises
 
 1. Use _.reduce to multiply all the values in an array.
 

--- a/underscore-loops/callbackExercises.md
+++ b/underscore-loops/callbackExercises.md
@@ -1,4 +1,4 @@
-##Callback exercises
+## Callback exercises
 
 1. Use _.each to loop through an array and console.log() all the values. Now use it to console.log() the indices. How would this be different if you were looping through an object?
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
